### PR TITLE
Fix widget test app reference

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:car_maintenance_tracker/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const CarMaintenanceApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- update widget test to run `CarMaintenanceApp`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c2e0dc8083238f4709b3341de3fd

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the test application reference in `widget_test.dart` by replacing `MyApp` with `CarMaintenanceApp`.

### Why are these changes being made?

The test was using an outdated reference to `MyApp` which has been renamed or replaced by `CarMaintenanceApp` in the codebase, ensuring the test accurately reflects the current state of the application. This correction is necessary for the test suite to properly build and verify the functionality of the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->